### PR TITLE
Added required module to cabal file

### DIFF
--- a/lambdalumps.cabal
+++ b/lambdalumps.cabal
@@ -37,6 +37,7 @@ library
     , rhine-gloss
   exposed-modules:
       Gloss.Render
+      Model.DifficultyManager
       Model.Gamestate
       Model.Lib
       Model.RandomTetronimo


### PR DESCRIPTION
Without this change, stack gives a warning about a module which is missing from the list of exposed modules. On some systems, this is fine, but on Nixos this causes the linker to fail.

This Pull Request exposes the required module.