### PR TITLE
Wallkick implemented, fixed rotation bug

### DIFF
--- a/src/IO/Drop.hs
+++ b/src/IO/Drop.hs
@@ -19,8 +19,6 @@ dropTet tet blocks =
 
 
 
-isInside :: Tetronimo -> SettledBlocks -> Bool
-isInside tet blocks = any (\pos -> pos `elem` blocks) [first tet, second tet, third tet, fourth tet]
 
 
 dropOne :: Pos -> Pos

--- a/src/IO/Interface.hs
+++ b/src/IO/Interface.hs
@@ -29,7 +29,7 @@ parseEvent (G.EventKey key keyState _ _ ) game
     -- handle rotation
     | G.SpecialKey G.KeyTab    <- key
     , G.Down                   <- keyState
-    = game {currentTetronimo = (rotateCW (currentTetronimo game))}
+    = game {currentTetronimo = (rotateTet (currentTetronimo game) (settledTetronimos game))}
     -- handle drops
     | G.SpecialKey G.KeyEnter  <- key
     , G.Down                   <- keyState

--- a/src/IO/Rotate.hs
+++ b/src/IO/Rotate.hs
@@ -1,20 +1,66 @@
-module IO.Rotate where
+module IO.Rotate (rotateTet) where
 
 import Model.Tetronimo
+import Model.Lib (isInside)
 
---Rotation Functions
 
-rotateCW :: Tetronimo -> Tetronimo
-rotateCW tet
-    | s == OShape = tet
-    | (s == IShape) && (edgeGuard tet) = rotateICW tet
-    | (s == SShape) && (edgeGuard tet) = rotateSCW tet
-    | (s == ZShape) && (edgeGuard tet) = rotateZCW tet
-    | (s == LShape) && (edgeGuard tet) = rotateLCW tet
-    | (s == JShape) && (edgeGuard tet) = rotateJCW tet
-    | (s == TShape) && (edgeGuard tet) = rotateTCW tet
-    | otherwise = tet
-        where s = shape tet
+-- | Rotate a tetronimo. If there isn't space to rotate, wallkick
+--   (right first, then left)
+rotateTet :: Tetronimo -> SettledBlocks -> Tetronimo
+rotateTet tet blocks
+  | isValidPosition rotated = rotated
+  | isValidPosition rotatedRight = rotatedRight
+  | isValidPosition rotatedLeft = rotatedLeft
+  | otherwise = tet
+  where
+    rotated      = tryRotate tet
+    rotatedRight = tryRotate (kickRight tet)
+    rotatedLeft  = tryRotate (kickLeft tet)
+    kickLeft  = kick pred
+    kickRight = kick succ
+    isValidPosition tet = not (tet `isInside` blocks) && not (outsideBounds tet)
+
+
+-- | Check if a tetronimo is outside the bounds of the playarea
+outsideBounds :: Tetronimo -> Bool
+outsideBounds tet = any (<0) xs || any (>9) xs || any (<0) ys
+  where
+    xs = map xcoord [first tet, second tet, third tet, fourth tet]
+    ys = map ycoord [first tet, second tet, third tet, fourth tet]
+
+
+-- | kick is a convinience function, that modifies the xcoords of
+--   a tetronimo according to the function it is given
+kick :: (Int -> Int) -> Tetronimo -> Tetronimo
+kick f tet =
+  tet { first  = Pos (f x1) y1
+      , second = Pos (f x2) y2
+      , third  = Pos (f x3) y3
+      , fourth = Pos (f x4) y4
+      }
+  where
+    Pos x1 y1 = first tet
+    Pos x2 y2 = second tet
+    Pos x3 y3 = third tet
+    Pos x4 y4 = fourth tet
+
+
+-- | Try to rotate a tetronimo.
+--   this function does no tests to see if it results in a valid position
+tryRotate tet =
+    (case shape tet of
+        OShape -> id
+        IShape -> rotateICW
+        SShape -> rotateSCW
+        ZShape -> rotateZCW
+        LShape -> rotateLCW
+        JShape -> rotateJCW
+        TShape -> rotateTCW
+    ) tet
+
+
+-- Rotation Functions
+
 
 rotateICW :: Tetronimo -> Tetronimo
 rotateICW tet
@@ -259,18 +305,3 @@ rotateJCW tet
             y3 = (ycoord $ third tet)
             y4 = (ycoord $ fourth tet)
 
-edgeGuard :: Tetronimo -> Bool
-edgeGuard tet
-  | (pred x1) < 0 = False
-  | (pred x2) < 0 = False
-  | (pred x3) < 0 = False
-  | (pred x4) < 0 = False
-  | (succ x1) > 9 = False
-  | (succ x2) > 9 = False
-  | (succ x3) > 9 = False
-  | (succ x4) > 9 = False
-  | otherwise     = True
-    where x1 = (xcoord $ first tet)
-          x2 = (xcoord $ second tet)
-          x3 = (xcoord $ third tet)
-          x4 = (xcoord $ fourth tet)

--- a/src/Model/Lib.hs
+++ b/src/Model/Lib.hs
@@ -77,3 +77,6 @@ collapseBlocks xs = go 0 xs
 
 settleTetronimo :: Tetronimo -> SettledBlocks
 settleTetronimo tet = [first tet, second tet, third tet, fourth tet]
+
+isInside :: Tetronimo -> SettledBlocks -> Bool
+isInside tet blocks = any (\pos -> pos `elem` blocks) [first tet, second tet, third tet, fourth tet]

--- a/src/RhineGloss/Arrowized/IO/Interface.hs
+++ b/src/RhineGloss/Arrowized/IO/Interface.hs
@@ -44,7 +44,7 @@ parseEvent' (G.EventKey key keyState _ _ ) game
     -- handle rotation
     | G.SpecialKey G.KeyTab    <- key
     , G.Down                   <- keyState
-    = game {currentTetronimo = (rotateCW (currentTetronimo game))}
+    = game {currentTetronimo = (rotateTet (currentTetronimo game) (settledTetronimos game))}
     -- handle drops
     | G.SpecialKey G.KeyEnter  <- key
     , G.Down                   <- keyState

--- a/src/RhineGloss/Arrowized/Model/Lib.hs
+++ b/src/RhineGloss/Arrowized/Model/Lib.hs
@@ -72,3 +72,6 @@ collapseBlocks xs = go 0 xs
 
 settleTetronimo :: Tetronimo -> SettledBlocks
 settleTetronimo tet = [first tet, second tet, third tet, fourth tet]
+
+isInside :: Tetronimo -> SettledBlocks -> Bool
+isInside tet blocks = any (\pos -> pos `elem` blocks) [first tet, second tet, third tet, fourth tet]


### PR DESCRIPTION
This pull request does 2 things:

* Replaces `rotateCW` with `rotateTet`, an implementation that prevents tetronimos from rotating into illegal positions, and also implements wallkick (so tetronimos don't glue themselves to the walls)
* Moves the `isInside` function into `Model.Lib`

These same changes also happen for the `RhineGloss.Arrowized` code.